### PR TITLE
Added support for Gentoo

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,12 +1,6 @@
 ---
-
-- name: Test distribution
-  assert:
-    that: >
-      ansible_os_family == "RedHat"
-
-- name: Install sssd package for RedHat
-  yum:
+- name: Install sssd package
+  package:
     name: "{{ sssd_pkg }}"
     state: present
   notify:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,9 +1,7 @@
 ---
 
 - name: Test distribution
-  assert:
-    that: >
-      ansible_os_family == "RedHat"
+
 
 - name: Install sssd package for RedHat
   yum:
@@ -13,6 +11,19 @@
     - Restart sssd
   tags:
     - sssd_pkg
+  when:
+    ansible_os_family == 'RedHat'
+
+- name: Install ssd package for Gentoo
+  portage:
+    name: "{{ sssd_pkg }}"
+    state: present
+  notify:
+    - Restart sssd
+  tags:
+    - sssd_pkg
+  when:
+    ansible_os_family == 'Gentoo'
 
 - name: Configure sssd service
   template:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,25 +1,12 @@
 ---
-- name: Install sssd package for RedHat
-  yum:
+- name: Install sssd package
+  package:
     name: "{{ sssd_pkg }}"
     state: present
   notify:
     - Restart sssd
   tags:
     - sssd_pkg
-  when:
-    ansible_os_family == 'RedHat'
-
-- name: Install sssd package for Gentoo
-  portage:
-    name: "{{ sssd_pkg }}"
-    state: present
-  notify:
-    - Restart sssd
-  tags:
-    - sssd_pkg
-  when:
-    ansible_os_family == 'Gentoo'
 
 - name: Configure sssd service
   template:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,8 +1,4 @@
 ---
-
-- name: Test distribution
-
-
 - name: Install sssd package for RedHat
   yum:
     name: "{{ sssd_pkg }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -10,7 +10,7 @@
   when:
     ansible_os_family == 'RedHat'
 
-- name: Install ssd package for Gentoo
+- name: Install sssd package for Gentoo
   portage:
     name: "{{ sssd_pkg }}"
     state: present


### PR DESCRIPTION
Added support for Gentoo, by adding a task that uses portage to install the {{ sssd_pkg }} on a Gentoo system.
Removed the assert that asserted that it was only run on RedHat family systems and added this to the yum task, and added an assertion to the Gentoo task to ensure that it only was run on Gentoo systems.
