### PR TITLE
Changed to using the package module instead

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,12 +1,6 @@
 ---
-
-- name: Test distribution
-  assert:
-    that: >
-      ansible_os_family == "RedHat"
-
-- name: Install sssd package for RedHat
-  yum:
+- name: Install sssd package
+  package:
     name: "{{ sssd_pkg }}"
     state: present
   notify:


### PR DESCRIPTION
Using the package module instead of a distro specific module makes the role distro agnostic and should work on most, if not all, due to the sssd_pkg being a variable and not hardcoded.

Thus if a distro calls their sssd package something else than sssd and that distro is supported by the package module, they can now use this role to install sssd.
